### PR TITLE
Logstash 2.0 removed the usage of type and tags to do filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+ - Update tests to remove obsolete options
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/logstash-filter-clone.gemspec
+++ b/logstash-filter-clone.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-clone'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The clone filter is for duplicating events."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -8,7 +8,6 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          type => "original"
           clones => ["clone", "clone", "clone"]
         }
       }
@@ -32,8 +31,6 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          type => "nginx-access"
-          tags => ['TESTLOG']
           clones => ["nginx-access-clone1", "nginx-access-clone2"]
           add_tag => ['RABBIT','NO_ES']
           remove_tag => ["TESTLOG"]
@@ -60,7 +57,6 @@ describe LogStash::Filters::Clone do
       reject { subject[2]["tags"] }.include? "TESTLOG"
       insist { subject[2]["tags"] }.include? "RABBIT"
       insist { subject[2]["tags"] }.include? "NO_ES"
-
     end
   end
 


### PR DESCRIPTION
Logstash 2.0 removed the usage of type and tags to do filtering, you can use conditionals to achieve
the same behavior.

Fixes #2