### PR TITLE
Allow the clones to be specified by an array in the event

### DIFF
--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -11,6 +11,8 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
 
   # A new clone will be created with the given type for each type in this list.
   config :clones, :validate => :array, :default => []
+  # if you want to dynamically specify the list of clones based on a field in the event
+  config :clone_array_name, :validate => :string
 
   public
   def register
@@ -19,7 +21,12 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
 
   public
   def filter(event)
-    @clones.each do |type|
+    if @clone_array_name
+      clones = event.get(@clone_array_name);
+    else
+      clones = @clones;
+    end
+    clones.each do |type|
       clone = event.clone
       clone.set("type", type)
       filter_matched(clone)

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -62,6 +62,29 @@ describe LogStash::Filters::Clone do
     end
   end
 
+  describe "clone_array_name" do
+    config <<-CONFIG
+      filter {
+        clone {
+          clone_array_name => "clones"
+        }
+      }
+    CONFIG
+
+    sample("type" => "nginx-access", "tags" => ["TESTLOG"], "message" => "hello world", "clones" => ["1","2","3"]) do
+      insist { subject }.is_a? Array
+      insist { subject.length } == 4
+
+      insist { subject[0].get("type") } == "nginx-access"
+      #Initial event remains unchanged
+      insist { subject[0].get("tags") }.include? "TESTLOG"
+      #All clones go through filter_matched
+      insist { subject[1].get("type") } == "1"
+      insist { subject[2].get("type") } == "2"
+      insist { subject[3].get("type") } == "3"
+    end
+  end
+
   describe "Bug LOGSTASH-1225" do
     ### LOGSTASH-1225: Cannot clone events containing numbers.
     config <<-CONFIG


### PR DESCRIPTION
This change allows the list of clones to come from a field in the event for those cases where you don't know the number of clones that will be needed ahead of time.
