### PR TITLE
Specify custom target field for clone type

### DIFF
--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -14,6 +14,9 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
 
   # A new clone will be created with the given type for each type in this list.
   config :clones, :validate => :array, :default => []
+  
+  # Optional configuration to specify field in which to store the clone type
+  config :clone_type_field, :validate => :string, :default = "type"
 
   public
   def register
@@ -24,7 +27,7 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
   def filter(event)
     @clones.each do |type|
       clone = event.clone
-      clone.set("type", type)
+      clone.set(@clone_type_field, type)
       filter_matched(clone)
       @logger.debug("Cloned event", :clone => clone, :event => event)
 

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -16,7 +16,7 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
   config :clones, :validate => :array, :default => []
   
   # Optional configuration to specify field in which to store the clone type
-  config :clone_type_field, :validate => :string, :default = "type"
+  config :clone_type_field, :validate => :string, :default => "type"
 
   public
   def register

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -29,6 +29,31 @@ describe LogStash::Filters::Clone do
     end
   end
 
+  describe "custom type field" do
+    config <<-CONFIG
+      filter {
+        clone {
+          clones => ["clone", "clone", "clone"]
+          clone_type_field => "custom_field"          
+        }
+      }
+    CONFIG
+
+    sample("message" => "hello world", "type" => "original") do
+      insist { subject }.is_a? Array
+      insist { subject.length } == 4
+      subject.each_with_index do |s,i|
+        if i == 0 # last one should be 'original'
+          insist { s.get("type") } == "original"
+        else
+          insist { s.get("type")} == "original"
+          insist { s.get("custom_field")} == "clone"
+        end
+        insist { s.get("message") } == "hello world"
+      end
+    end
+  end
+
   describe "Complex use" do
     config <<-CONFIG
       filter {


### PR DESCRIPTION
Resolves https://github.com/logstash-plugins/logstash-filter-clone/issues/8 which is a bug that could lead to data loss by overwriting original "type" field in the event.