### PR TITLE
WIP make `clones` a hash so that arbitrary fields can be used

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -21,7 +21,8 @@ include::{include_path}/plugin_header.asciidoc[]
 ==== Description
 
 The clone filter is for duplicating events.
-A clone will be created for each type in the clone list.
+A clone will be created for each value in the clone list.
+By default `clones` values overwrite the `type` field, or you can specify an optional `field`.
 The original event is left unchanged.
 Created events are inserted into the pipeline 
 as normal events and will be processed by the remaining pipeline configuration 
@@ -35,6 +36,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-field>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-clones>> |<<hash,hash>>|Yes
 |=======================================================================
 
@@ -42,6 +44,22 @@ Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options suppo
 filter plugins.
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-fields"]
+===== `field`
+
+  * Value type is <<string,string>>
+  * Default value is `type`
+
+Specify the field into which `clones` values will be added.
+Example:
+[source,ruby]
+   filter { 
+     clone {
+       field => "clone"
+       clones => [ "clone1", "clone2" ]
+     }
+   }
 
 [id="plugins-{type}s-{plugin}-clones"]
 ===== `clones` 
@@ -56,7 +74,7 @@ Example:
 [source,ruby]
    filter { 
      clone {
-       clones => { "field" => "value" }
+       clones => [ "clone1", "clone2" ]
      }
    }
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -35,7 +35,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-clones>> |<<array,array>>|Yes
+| <<plugins-{type}s-{plugin}-clones>> |<<hash,hash>>|Yes
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -47,13 +47,22 @@ filter plugins.
 ===== `clones` 
 
   * This is a required setting.
-  * Value type is <<array,array>>
+  * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
 A new clone will be created with the given type for each type in this list.
 
-Note: setting an empty array will not create any clones. A warning message is logged.
+Example:
+[source,ruby]
+   filter { 
+     clone {
+       clones => { "fieldname" => "value" }
+     }
+   }
+
+Note: setting an empty hash will not create any clones. A warning message is logged.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
+

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -13,18 +13,19 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
   config_name "clone"
 
   # A new clone will be created with the given type for each type in this list.
-  config :clones, :validate => :hash, :required => true
+  config :field, :validate => :string, :required => false, :default => "clone"
+  config :values, :validate => :array, :required => true
 
   public
   def register
-    logger.warn("The parameter 'clones' is empty, so no clones will be created.") if @clones.empty?
+    logger.warn("The parameter 'clones' is empty, so no clones will be created.") if @values.empty?
   end
 
   public
   def filter(event)
-    @clones.each do |field, value|
+    @values.each do |value|
       clone = event.clone
-      clone.set(field, value)
+      clone.set(field,value)
       filter_matched(clone)
       @logger.debug? && @logger.debug("Cloned event", :clone => clone, :event => event)
 

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -13,7 +13,7 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
   config_name "clone"
 
   # A new clone will be created with the given type for each type in this list.
-  config :clones, :validate => :array, :required => true
+  config :clones, :validate => :hash, :required => true
 
   public
   def register
@@ -22,11 +22,11 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
 
   public
   def filter(event)
-    @clones.each do |type|
+    @clones.each do |field, value|
       clone = event.clone
-      clone.set("type", type)
+      clone.set(field, value)
       filter_matched(clone)
-      @logger.debug("Cloned event", :clone => clone, :event => event)
+      @logger.debug? && @logger.debug("Cloned event", :clone => clone, :event => event)
 
       # Push this new event onto the stack at the LogStash::FilterWorker
       yield clone

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -13,21 +13,21 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
   config_name "clone"
 
   # A new clone will be created with the given type for each type in this list.
-  config :field, :validate => :string, :required => false, :default => "clone"
-  config :values, :validate => :array, :required => true
+  config :field, :validate => :string, :required => false, :default => "type"
+  config :clones, :validate => :array, :required => true
 
   public
   def register
-    logger.warn("The parameter 'clones' is empty, so no clones will be created.") if @values.empty?
+    logger.warn("The parameter 'clones' is empty, so no clones will be created.") if @clones.empty?
   end
 
   public
   def filter(event)
-    @values.each do |value|
+    @clones.each do |value|
       clone = event.clone
       clone.set(field,value)
       filter_matched(clone)
-      @logger.debug? && @logger.debug("Cloned event", :clone => clone, :event => event)
+      @logger.debug("Cloned event", :clone => clone, :event => event)
 
       # Push this new event onto the stack at the LogStash::FilterWorker
       yield clone

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -10,19 +10,24 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          clones => ["clone", "clone", "clone"]
+          clones => {
+            "type" => "clone"
+            "clone" => "clone1"
+          }
         }
       }
     CONFIG
 
     sample("message" => "hello world", "type" => "original") do
-      insist { subject }.is_a? Array
-      insist { subject.length } == 4
+      insist { subject }.is_a? Hash
+      insist { subject.length } == 3
       subject.each_with_index do |s,i|
         if i == 0 # last one should be 'original'
           insist { s.get("type") } == "original"
-        else
+        else if i = 1
           insist { s.get("type")} == "clone"
+        else
+          insist { s.get("clone")} == "clone1"
         end
         insist { s.get("message") } == "hello world"
       end
@@ -33,7 +38,10 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          clones => ["nginx-access-clone1", "nginx-access-clone2"]
+          clones => {
+            "clone" => "nginx-access-clone1"
+            "type" => "nginx-access-clone2"
+          }
           add_tag => ['RABBIT','NO_ES']
           remove_tag => ["TESTLOG"]
         }
@@ -50,7 +58,7 @@ describe LogStash::Filters::Clone do
       reject { subject[0].get("tags") }.include? "RABBIT"
       reject { subject[0].get("tags") }.include? "NO_ES"
       #All clones go through filter_matched
-      insist { subject[1].get("type") } == "nginx-access-clone1"
+      insist { subject[1].get("clone") } == "nginx-access-clone1"
       reject { subject[1].get("tags") }.include? "TESTLOG"
       insist { subject[1].get("tags") }.include? "RABBIT"
       insist { subject[1].get("tags") }.include? "NO_ES"
@@ -67,7 +75,7 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          clones => [ 'clone1' ]
+          clones => { 'clone1' => 'clone1' }
         }
       }
     CONFIG

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -24,7 +24,7 @@ describe LogStash::Filters::Clone do
       subject.each_with_index do |s,i|
         if i == 0 # last one should be 'original'
           insist { s.get("type") } == "original"
-        elseif i = 1
+        elsif i = 1
           insist { s.get("type")} == "clone"
         else
           insist { s.get("clone")} == "clone1"

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -24,8 +24,6 @@ describe LogStash::Filters::Clone do
       subject.each_with_index do |s,i|
         if i == 0 # last one should be 'original'
           insist { s.get("type") } == "original"
-        elsif i = 1
-          insist { s.get("type")} == "clone"
         else
           insist { s.get("clone")} == "clone1"
         end

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -19,7 +19,7 @@ describe LogStash::Filters::Clone do
     CONFIG
 
     sample("message" => "hello world", "type" => "original") do
-      insist { subject }.is_a? Hash
+      insist { subject }.is_a? Array
       insist { subject.length } == 3
       subject.each_with_index do |s,i|
         if i == 0 # last one should be 'original'

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -10,22 +10,19 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          clones => {
-            "type" => "clone"
-            "clone" => "clone1"
-          }
+          clones => ["clone", "clone", "clone"]
         }
       }
     CONFIG
 
     sample("message" => "hello world", "type" => "original") do
       insist { subject }.is_a? Array
-      insist { subject.length } == 3
+      insist { subject.length } == 4
       subject.each_with_index do |s,i|
         if i == 0 # last one should be 'original'
           insist { s.get("type") } == "original"
         else
-          insist { s.get("clone")} == "clone1"
+          insist { s.get("type")} == "clone"
         end
         insist { s.get("message") } == "hello world"
       end
@@ -36,10 +33,7 @@ describe LogStash::Filters::Clone do
     config <<-CONFIG
       filter {
         clone {
-          clones => {
-            "clone" => "nginx-access-clone1"
-            "type" => "nginx-access-clone2"
-          }
+          clones => ["nginx-access-clone1", "nginx-access-clone2"]
           add_tag => ['RABBIT','NO_ES']
           remove_tag => ["TESTLOG"]
         }
@@ -56,7 +50,7 @@ describe LogStash::Filters::Clone do
       reject { subject[0].get("tags") }.include? "RABBIT"
       reject { subject[0].get("tags") }.include? "NO_ES"
       #All clones go through filter_matched
-      insist { subject[1].get("clone") } == "nginx-access-clone1"
+      insist { subject[1].get("type") } == "nginx-access-clone1"
       reject { subject[1].get("tags") }.include? "TESTLOG"
       insist { subject[1].get("tags") }.include? "RABBIT"
       insist { subject[1].get("tags") }.include? "NO_ES"
@@ -68,12 +62,34 @@ describe LogStash::Filters::Clone do
     end
   end
 
+  describe "Other Field" do
+    config <<-CONFIG
+      filter {
+        clone {
+          field => "clone"
+          clones => ["clone1", "clone2"]
+        }
+      }
+    CONFIG
+
+    sample("message" => "hello world", "type" => "original") do
+      insist { subject }.is_a? Array
+      insist { subject.length } == 3
+      insist { subject[1].get("clone") } == "clone1"
+      insist { subject[2].get("clone") } == "clone2"
+      subject.each do |s|
+        insist { s.get("type") } == "original"
+        insist { s.get("message") } == "hello world"
+      end
+    end
+  end
+
   describe "Bug LOGSTASH-1225" do
     ### LOGSTASH-1225: Cannot clone events containing numbers.
     config <<-CONFIG
       filter {
         clone {
-          clones => { 'clone1' => 'clone1' }
+          clones => [ 'clone1' ]
         }
       }
     CONFIG

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -24,7 +24,7 @@ describe LogStash::Filters::Clone do
       subject.each_with_index do |s,i|
         if i == 0 # last one should be 'original'
           insist { s.get("type") } == "original"
-        else if i = 1
+        elseif i = 1
           insist { s.get("type")} == "clone"
         else
           insist { s.get("clone")} == "clone1"


### PR DESCRIPTION


Using the deprecated `type` field strikes me as a problem. This PR changes clone config from an array, which only operates on the `type` field:

```
filter {
  clone {
    clones => [ "type1", "type2" ]
  }
}
```

to a hash, operating on any arbitrary field:
```
filter {
  clone {
    clones => {
      "field1" => "val1"
      "field2" => "val2"
    }
  }
}
```

Effectively, the `clones` hash operates like `add_field` on the new document(s).

Documentation has been updated to reflect the change.
