### PR TITLE
update test to not use pipelines or insist

### DIFF
--- a/logstash-filter-clone.gemspec
+++ b/logstash-filter-clone.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'logstash-codec-plain'
-  s.add_development_dependency 'insist'
 end
 

--- a/logstash-filter-clone.gemspec
+++ b/logstash-filter-clone.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'insist'
 end
 

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -1,81 +1,77 @@
 # encoding: utf-8
-
 require "logstash/devutils/rspec/spec_helper"
-require "insist"
 require "logstash/filters/clone"
 
 describe LogStash::Filters::Clone do
 
-  describe "all defaults" do
-    type "original"
-    config <<-CONFIG
-      filter {
-        clone {
-          clones => ["clone", "clone", "clone"]
-        }
-      }
-    CONFIG
+  describe "#filter" do
+    subject { described_class.new(settings) }
+    let(:event) { LogStash::Event.new(input) }
+    before(:each) do
+      subject.register
+    end
+    describe "all defaults" do
+      let(:input) { { "message" => "hello world", "type" => "original" } }
+      let(:settings) { { "clones" => ["clone", "clone", "clone"] } }
 
-    sample("message" => "hello world", "type" => "original") do
-      insist { subject }.is_a? Array
-      insist { subject.length } == 4
-      subject.each_with_index do |s,i|
-        if i == 0 # last one should be 'original'
-          insist { s.get("type") } == "original"
-        else
-          insist { s.get("type")} == "clone"
+      it "should generate new clones + current event" do
+        events = [event]
+        subject.filter(event) {|e| events << e }
+        expect(events.length).to eq(4)
+        events.each_with_index do |s,i|
+          if i == 0 # last one should be 'original'
+            expect(s.get("type")).to eq("original")
+          else
+            expect(s.get("type")).to eq("clone")
+          end
+          expect(s.get("message")).to eq("hello world")
         end
-        insist { s.get("message") } == "hello world"
       end
     end
-  end
 
-  describe "Complex use" do
-    config <<-CONFIG
-      filter {
-        clone {
-          clones => ["nginx-access-clone1", "nginx-access-clone2"]
-          add_tag => ['RABBIT','NO_ES']
-          remove_tag => ["TESTLOG"]
+    describe "Complex use" do
+      let(:settings) do
+        { "clones" => ["nginx-access-clone1", "nginx-access-clone2"],
+          "add_tag" => ['RABBIT','NO_ES'],
+          "remove_tag" => ["TESTLOG"]
         }
-      }
-    CONFIG
+      end
+      let(:input) { { "type" => "nginx-access", "tags" => ["TESTLOG"], "message" => "hello world" } }
 
-    sample("type" => "nginx-access", "tags" => ["TESTLOG"], "message" => "hello world") do
-      insist { subject }.is_a? Array
-      insist { subject.length } == 3
+      it "works as expected" do
+        events = [event]
+        subject.filter(event) {|e| events << e }
+        expect(events.length).to eq(3)
 
-      insist { subject[0].get("type") } == "nginx-access"
-      #Initial event remains unchanged
-      insist { subject[0].get("tags") }.include? "TESTLOG"
-      reject { subject[0].get("tags") }.include? "RABBIT"
-      reject { subject[0].get("tags") }.include? "NO_ES"
-      #All clones go through filter_matched
-      insist { subject[1].get("type") } == "nginx-access-clone1"
-      reject { subject[1].get("tags") }.include? "TESTLOG"
-      insist { subject[1].get("tags") }.include? "RABBIT"
-      insist { subject[1].get("tags") }.include? "NO_ES"
+        expect(events[0].get("type")).to eq("nginx-access")
+        #Initial event remains unchanged
+        expect(events[0].get("tags")).to include("TESTLOG")
+        expect(events[0].get("tags")).to_not include("RABBIT")
+        expect(events[0].get("tags")).to_not include("NO_ES")
+        #All clones go through filter_matched
+        expect(events[1].get("type")).to eq("nginx-access-clone1")
+        expect(events[1].get("tags")).to_not include("TESTLOG")
+        expect(events[1].get("tags")).to include("RABBIT")
+        expect(events[1].get("tags")).to include("NO_ES")
 
-      insist { subject[2].get("type") } == "nginx-access-clone2"
-      reject { subject[2].get("tags") }.include? "TESTLOG"
-      insist { subject[2].get("tags") }.include? "RABBIT"
-      insist { subject[2].get("tags") }.include? "NO_ES"
+        expect(events[2].get("type")).to eq("nginx-access-clone2")
+        expect(events[2].get("tags")).to_not include("TESTLOG")
+        expect(events[2].get("tags")).to include("RABBIT")
+        expect(events[2].get("tags")).to include("NO_ES")
+      end
     end
-  end
 
-  describe "Bug LOGSTASH-1225" do
-    ### LOGSTASH-1225: Cannot clone events containing numbers.
-    config <<-CONFIG
-      filter {
-        clone {
-          clones => [ 'clone1' ]
-        }
-      }
-    CONFIG
+    describe "Bug LOGSTASH-1225" do
+      ### LOGSTASH-1225: Cannot clone events containing numbers.
+      let(:settings) { { "clones" => [ 'clone1' ] } }
+      let(:input) { { "type" => "bug-1225", "message" => "unused", "number" => 5 } }
 
-    sample("type" => "bug-1225", "message" => "unused", "number" => 5) do
-      insist { subject[0].get("number") } == 5
-      insist { subject[1].get("number") } == 5
+      it "clones events containing numbers" do
+        events = [event]
+        subject.filter(event) {|e| events << e }
+        expect(events[0].get("number")).to eq(5)
+        expect(events[1].get("number")).to eq(5)
+      end
     end
   end
 


### PR DESCRIPTION
this PR fixes tests since devutils doesn't give us the plain codec as a dependency anymore.

It also refactors the test to not rely on the pipeline or the insist library. It now instantiates the filter directly.