### PR TITLE
add ecs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+  - Add ECS compatibility [#24](https://github.com/logstash-plugins/logstash-filter-clone/pull/24)
+
 ## 4.0.0
   - Make 'clones' a required option
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -69,7 +69,7 @@ ECS disabled
 {
       "@version" => "1",
       "sequence" => 0,
-       "message" => "some messages",
+       "message" => "Hello World!",
     "@timestamp" => 2021-03-24T11:20:36.226Z,
           "type" => "sun",
           "host" => "example.com"
@@ -77,7 +77,7 @@ ECS disabled
 {
       "@version" => "1",
       "sequence" => 0,
-       "message" => "some messages",
+       "message" => "Hello World!",
     "@timestamp" => 2021-03-24T11:20:36.226Z,
           "type" => "moon",
           "host" => "example.com"
@@ -93,7 +93,7 @@ ECS enabled
     ],
       "sequence" => 0,
     "@timestamp" => 2021-03-23T20:25:10.042Z,
-       "message" => "some messages",
+       "message" => "Hello World!",
       "@version" => "1",
           "host" => "example.com"
 }
@@ -103,7 +103,7 @@ ECS enabled
     ],
       "sequence" => 0,
     "@timestamp" => 2021-03-23T20:25:10.042Z,
-       "message" => "some messages",
+       "message" => "Hello World!",
       "@version" => "1",
           "host" => "example.com"
 }

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -116,7 +116,7 @@ Note: setting an empty array will not create any clones. A warning message is lo
 
 * Value type is <<string,string>>
 * Supported values are:
-** `disabled`: unstructured geo data added at root level
+** `disabled`: does not use ECS-compatible field names
 ** `v1`: uses fields that are compatible with Elastic Common Schema
 * Default value depends on which version of Logstash is running:
 ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -35,6 +35,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-clones>> |<<array,array>>|Yes
 |=======================================================================
 
@@ -43,14 +44,28 @@ filter plugins.
 
 &nbsp;
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: unstructured geo data added at root level
+** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[client][geo][country_name]`)
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-syslog_pri_field_name>>.
+
 [id="plugins-{type}s-{plugin}-clones"]
 ===== `clones` 
 
   * This is a required setting.
   * Value type is <<array,array>>
   * There is no default value for this setting.
-
-A new clone will be created with the given type for each type in this list.
+  * ECS Compatibility disabled: a new clone will be created with the given type in this list.
+  * ECS Compatibility enabled: a new clone will be created with a `tag` of the given type in this list.
 
 Note: setting an empty array will not create any clones. A warning message is logged.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,7 +56,7 @@ filter plugins.
 ** Otherwise, the default value is `disabled`.
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-syslog_pri_field_name>>.
+The value of this setting affects the _default_ value of `type` and `tags`, see <<plugins-{type}s-{plugin}-clones>>
 
 [id="plugins-{type}s-{plugin}-clones"]
 ===== `clones` 
@@ -64,8 +64,64 @@ The value of this setting affects the _default_ value of <<plugins-{type}s-{plug
   * This is a required setting.
   * Value type is <<array,array>>
   * There is no default value for this setting.
-  * ECS Compatibility disabled: a new clone will be created with the given type in this list.
-  * ECS Compatibility enabled: a new clone will be created with a `tag` of the given type in this list.
+
+ECS Compatibility disabled: a new clone will be created with a `type` of the given type in this list.
+
+ECS Compatibility enabled: a new clone will be created with a `tag` of the given type in this list.
+
+Example:
+[source,ruby]
+    filter {
+      clone {
+        clones => ["sun", "moon"]
+      }
+    }
+
+ECS disabled
+[source,text]
+-----
+{
+      "@version" => "1",
+      "sequence" => 0,
+       "message" => "some messages",
+    "@timestamp" => 2021-03-24T11:20:36.226Z,
+          "type" => "sun",
+          "host" => "example.com"
+}
+{
+      "@version" => "1",
+      "sequence" => 0,
+       "message" => "some messages",
+    "@timestamp" => 2021-03-24T11:20:36.226Z,
+          "type" => "moon",
+          "host" => "example.com"
+}
+-----
+
+ECS enabled
+[source,text]
+-----
+{
+          "tags" => [
+        [0] "sun"
+    ],
+      "sequence" => 0,
+    "@timestamp" => 2021-03-23T20:25:10.042Z,
+       "message" => "some messages",
+      "@version" => "1",
+          "host" => "example.com"
+}
+{
+          "tags" => [
+        [0] "moon"
+    ],
+      "sequence" => 0,
+    "@timestamp" => 2021-03-23T20:25:10.042Z,
+       "message" => "some messages",
+      "@version" => "1",
+          "host" => "example.com"
+}
+-----
 
 Note: setting an empty array will not create any clones. A warning message is logged.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -35,28 +35,14 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-clones>> |<<array,array>>|Yes
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
 filter plugins.
 
 &nbsp;
-
-[id="plugins-{type}s-{plugin}-ecs_compatibility"]
-===== `ecs_compatibility`
-
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: unstructured geo data added at root level
-** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[client][geo][country_name]`)
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`.
-
-Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-The value of this setting affects the _default_ value of `type` and `tags`, see <<plugins-{type}s-{plugin}-clones>>
 
 [id="plugins-{type}s-{plugin}-clones"]
 ===== `clones` 
@@ -124,6 +110,20 @@ ECS enabled
 -----
 
 Note: setting an empty array will not create any clones. A warning message is logged.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: unstructured geo data added at root level
+** `v1`: uses fields that are compatible with Elastic Common Schema
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of `type` and `tags`, see <<plugins-{type}s-{plugin}-clones>>
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -50,10 +50,24 @@ filter plugins.
   * This is a required setting.
   * Value type is <<array,array>>
   * There is no default value for this setting.
+  * a new clone will be created with a `type` of the given value in this list when ECS is disabled
+  * a new clone will be created with a `tags` of the given value in this list when ECS is enabled
 
-ECS Compatibility disabled: a new clone will be created with a `type` of the given type in this list.
+Note: setting an empty array will not create any clones. A warning message is logged.
 
-ECS Compatibility enabled: a new clone will be created with a `tag` of the given type in this list.
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: does not use ECS-compatible field names
+** `v1`: uses fields that are compatible with Elastic Common Schema
+* Default value depends on which version of Logstash is running:
+** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the behavior of the <<plugins-{type}s-{plugin}-clones>>
 
 Example:
 [source,ruby]
@@ -66,6 +80,13 @@ Example:
 ECS disabled
 [source,text]
 -----
+{
+      "@version" => "1",
+      "sequence" => 0,
+       "message" => "Hello World!",
+    "@timestamp" => 2021-03-24T11:20:36.226Z,
+          "host" => "example.com"
+}
 {
       "@version" => "1",
       "sequence" => 0,
@@ -88,6 +109,13 @@ ECS enabled
 [source,text]
 -----
 {
+      "sequence" => 0,
+    "@timestamp" => 2021-03-23T20:25:10.042Z,
+       "message" => "Hello World!",
+      "@version" => "1",
+          "host" => "example.com"
+}
+{
           "tags" => [
         [0] "sun"
     ],
@@ -108,23 +136,6 @@ ECS enabled
           "host" => "example.com"
 }
 -----
-
-Note: setting an empty array will not create any clones. A warning message is logged.
-
-[id="plugins-{type}s-{plugin}-ecs_compatibility"]
-===== `ecs_compatibility`
-
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: does not use ECS-compatible field names
-** `v1`: uses fields that are compatible with Elastic Common Schema
-* Default value depends on which version of Logstash is running:
-** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
-** Otherwise, the default value is `disabled`.
-
-Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-The value of this setting affects the _default_ value of `type` and `tags`, see <<plugins-{type}s-{plugin}-clones>>
-
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -25,7 +25,7 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
 
   def initialize(*params)
     super
-    @event_enhance_method = method( ecs_select[disabled: :set_event_type, v1: :add_event_tag] )
+    @enhance_clone_type_method = method( ecs_select[disabled: :set_event_type, v1: :add_event_tag] )
   end
 
   def register
@@ -36,7 +36,7 @@ class LogStash::Filters::Clone < LogStash::Filters::Base
   def filter(event)
     @clones.each do |type|
       clone = event.clone
-      @event_enhance_method.(clone, type)
+      @enhance_clone_type_method.(clone, type)
       filter_matched(clone)
       @logger.debug("Cloned event", :clone => clone, :event => event)
 

--- a/lib/logstash/filters/clone.rb
+++ b/lib/logstash/filters/clone.rb
@@ -9,6 +9,10 @@ require "logstash/plugin_mixins/ecs_compatibility_support"
 # Created events are inserted into the pipeline 
 # as normal events and will be processed by the remaining pipeline configuration 
 # starting from the filter that generated them (i.e. this plugin).
+#
+# ECS disabled: set the value of the root-level `type` (undefined in ECS) of each resulting event
+# to one of the values provided in its `clones` directive.
+# ECS enabled: add a `tags` of each resulting event to one of the values provided in its `clones` directive.
 class LogStash::Filters::Clone < LogStash::Filters::Base
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
 

--- a/logstash-filter-clone.gemspec
+++ b/logstash-filter-clone.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.1'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/logstash-filter-clone.gemspec
+++ b/logstash-filter-clone.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-clone'
-  s.version         = '4.0.0'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Duplicates events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/clone_spec.rb
+++ b/spec/filters/clone_spec.rb
@@ -1,92 +1,122 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/clone"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
 describe LogStash::Filters::Clone do
 
-  describe "#filter" do
-    subject { described_class.new(settings) }
-    let(:event) { LogStash::Event.new(input) }
-    before(:each) do
-      subject.register
-    end
-    describe "all defaults" do
-      let(:input) { { "message" => "hello world", "type" => "original" } }
-      let(:settings) { { "clones" => ["clone", "clone", "clone"] } }
+  describe "#filter", :ecs_compatibility_support, :aggregate_failures do
+    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
 
-      it "should generate new clones + current event" do
-        events = [event]
-        subject.filter(event) {|e| events << e }
-        expect(events.length).to eq(4)
-        events.each_with_index do |s,i|
-          if i == 0 # last one should be 'original'
-            expect(s.get("type")).to eq("original")
-          else
-            expect(s.get("type")).to eq("clone")
+      subject { described_class.new(settings) }
+      let(:event) { LogStash::Event.new(input) }
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
+        subject.register
+      end
+
+      describe "all defaults" do
+        let(:input) { { "message" => "hello world", "type" => "original" } }
+        let(:settings) { { "clones" => ["clone", "clone", "clone"] } }
+
+        it "should generate new clones + current event" do
+          events = [event]
+          subject.filter(event) {|e| events << e }
+          expect(events.length).to eq(4)
+          events.each_with_index do |s,i|
+            if ecs_compatibility == :disabled
+              if i == 0 # last one should be 'original'
+                expect(s.get("type")).to eq("original")
+              else
+                expect(s.get("type")).to eq("clone")
+              end
+              expect(s.get("message")).to eq("hello world")
+            else
+              expect(s.get("type")).to eq("original")
+              expect(s.get("message")).to eq("hello world")
+              expect(s.get("tags")).to include("clone") unless i == 0
+            end
           end
-          expect(s.get("message")).to eq("hello world")
+
+        end
+      end
+
+      describe "Complex use" do
+        let(:settings) do
+          { "clones" => ["nginx-access-clone1", "nginx-access-clone2"],
+            "add_tag" => ['RABBIT','NO_ES'],
+            "remove_tag" => ["TESTLOG"]
+          }
+        end
+        let(:input) { { "type" => "nginx-access", "tags" => ["TESTLOG"], "message" => "hello world" } }
+
+        it "works as expected" do
+          events = [event]
+          subject.filter(event) {|e| events << e }
+          expect(events.length).to eq(3)
+
+          if ecs_compatibility == :disabled
+            expect(events[0].get("type")).to eq("nginx-access")
+            #Initial event remains unchanged
+            expect(events[0].get("tags")).to include("TESTLOG")
+            expect(events[0].get("tags")).to_not include("RABBIT")
+            expect(events[0].get("tags")).to_not include("NO_ES")
+            #All clones go through filter_matched
+            expect(events[1].get("type")).to eq("nginx-access-clone1")
+            expect(events[1].get("tags")).to_not include("TESTLOG")
+            expect(events[1].get("tags")).to include("RABBIT")
+            expect(events[1].get("tags")).to include("NO_ES")
+
+            expect(events[2].get("type")).to eq("nginx-access-clone2")
+            expect(events[2].get("tags")).to_not include("TESTLOG")
+            expect(events[2].get("tags")).to include("RABBIT")
+            expect(events[2].get("tags")).to include("NO_ES")
+          else
+            expect(events[0].get("type")).to eq("nginx-access")
+            expect(events[0].get("tags")).to include("TESTLOG")
+            expect(events[0].get("tags")).to_not include("RABBIT")
+            expect(events[0].get("tags")).to_not include("NO_ES")
+
+            (1..2).each do |i|
+              expect(events[i].get("type")).to eq("nginx-access")
+              expect(events[i].get("tags")).to_not include("TESTLOG")
+              expect(events[i].get("tags")).to include("RABBIT")
+              expect(events[i].get("tags")).to include("NO_ES")
+            end
+
+            expect(events[1].get("tags")).to include("nginx-access-clone1")
+            expect(events[2].get("tags")).to include("nginx-access-clone2")
+          end
+        end
+      end
+
+      describe "Bug LOGSTASH-1225" do
+        ### LOGSTASH-1225: Cannot clone events containing numbers.
+        let(:settings) { { "clones" => [ 'clone1' ] } }
+        let(:input) { { "type" => "bug-1225", "message" => "unused", "number" => 5 } }
+
+        it "clones events containing numbers" do
+          events = [event]
+          subject.filter(event) {|e| events << e }
+          expect(events[0].get("number")).to eq(5)
+          expect(events[1].get("number")).to eq(5)
         end
       end
     end
 
-    describe "Complex use" do
-      let(:settings) do
-        { "clones" => ["nginx-access-clone1", "nginx-access-clone2"],
-          "add_tag" => ['RABBIT','NO_ES'],
-          "remove_tag" => ["TESTLOG"]
-        }
+    describe "#register" do
+      context "when clones is an empty array" do
+        subject { described_class.new("clones" => []) }
+        it "logs a warning" do
+          expect(subject.logger).to receive(:warn)
+          expect { subject.register }.to_not raise_error
+        end
       end
-      let(:input) { { "type" => "nginx-access", "tags" => ["TESTLOG"], "message" => "hello world" } }
-
-      it "works as expected" do
-        events = [event]
-        subject.filter(event) {|e| events << e }
-        expect(events.length).to eq(3)
-
-        expect(events[0].get("type")).to eq("nginx-access")
-        #Initial event remains unchanged
-        expect(events[0].get("tags")).to include("TESTLOG")
-        expect(events[0].get("tags")).to_not include("RABBIT")
-        expect(events[0].get("tags")).to_not include("NO_ES")
-        #All clones go through filter_matched
-        expect(events[1].get("type")).to eq("nginx-access-clone1")
-        expect(events[1].get("tags")).to_not include("TESTLOG")
-        expect(events[1].get("tags")).to include("RABBIT")
-        expect(events[1].get("tags")).to include("NO_ES")
-
-        expect(events[2].get("type")).to eq("nginx-access-clone2")
-        expect(events[2].get("tags")).to_not include("TESTLOG")
-        expect(events[2].get("tags")).to include("RABBIT")
-        expect(events[2].get("tags")).to include("NO_ES")
-      end
-    end
-
-    describe "Bug LOGSTASH-1225" do
-      ### LOGSTASH-1225: Cannot clone events containing numbers.
-      let(:settings) { { "clones" => [ 'clone1' ] } }
-      let(:input) { { "type" => "bug-1225", "message" => "unused", "number" => 5 } }
-
-      it "clones events containing numbers" do
-        events = [event]
-        subject.filter(event) {|e| events << e }
-        expect(events[0].get("number")).to eq(5)
-        expect(events[1].get("number")).to eq(5)
-      end
-    end
-  end
-
-  describe "#register" do
-    context "when clones is an empty array" do
-      subject { described_class.new("clones" => []) }
-      it "logs a warning" do
-        expect(subject.logger).to receive(:warn)
-        expect { subject.register }.to_not raise_error
-      end
-    end
-    context "when clones is not set" do
-      subject { described_class.new }
-      it "raises an error" do
-        expect { subject.register }.to raise_error(ArgumentError)
+      context "when clones is not set" do
+        subject { described_class.new }
+        it "raises an error" do
+          expect { subject.register }.to raise_error(ArgumentError)
+        end
       end
     end
   end


### PR DESCRIPTION
Elastic Common Schema Support
ECS add clone type to `tags` while legacy keeps `type` in root level

Fixed: https://github.com/logstash-plugins/logstash-filter-clone/issues/21