### PR TITLE
release 4.2.0

### DIFF
--- a/logstash-filter-clone.gemspec
+++ b/logstash-filter-clone.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-clone'
-  s.version         = '4.1.1'
+  s.version         = '4.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Duplicates events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
I failed to bump the version in #27 🤦🏼‍♂️ 

`CHANGELOG.md` on branch `main` already includes change notes:

> ## 4.2.0
>  - Added support for ECS v8 as alias for ECS v1 [#27](https://github.com/logstash-plugins/logstash-filter-clone/pull/27)
>
> -- [CHANGELOG.md@main](https://github.com/logstash-plugins/logstash-filter-clone/blob/main/CHANGELOG.md#420)